### PR TITLE
Fixes + Polish translation

### DIFF
--- a/lua/terrortown/entities/items/item_ttt_shootingspeed.lua
+++ b/lua/terrortown/entities/items/item_ttt_shootingspeed.lua
@@ -52,7 +52,7 @@ if SERVER then
 		wep.OnDrop = function(slf, ...)
 			DisableWeaponSpeed(slf)
 
-			if IsValid(slf) and isfunction(slf.OnDrop) then
+			if IsValid(slf) and isfunction(slf.OldOnDrop) then
 				slf:OldOnDrop(...)
 			end
 		end

--- a/lua/terrortown/entities/items/item_ttt_shootingspeed.lua
+++ b/lua/terrortown/entities/items/item_ttt_shootingspeed.lua
@@ -1,8 +1,8 @@
 ITEM.hud = Material("vgui/ttt/perks/hud_shootingspeed.png")
 ITEM.EquipMenuData = {
 	type = "item_passive",
-	name = "shootingspeed",
-	desc = "You shoot 30% faster!"
+	name = "item_shootingspeed",
+	desc = "item_shootingspeed_desc"
 }
 ITEM.material = "vgui/ttt/icon_shootingspeed"
 ITEM.CanBuy = {ROLE_TRAITOR, ROLE_DETECTIVE}

--- a/lua/terrortown/entities/items/item_ttt_shootingspeed.lua
+++ b/lua/terrortown/entities/items/item_ttt_shootingspeed.lua
@@ -77,6 +77,11 @@ if SERVER then
 		end
 	end
 	hook.Add("PlayerSwitchWeapon", "ShootingModifySpeed", shootingModifier)
+
+	function ITEM:Bought(ply)
+		if not IsValid(ply) then return end
+		ApplyWeaponSpeed(ply:GetActiveWeapon())
+	end
 else
 	net.Receive("ShootingSpeed", function()
 		local apply = net.ReadBool()

--- a/lua/terrortown/lang/en/shootingspeed.lua
+++ b/lua/terrortown/lang/en/shootingspeed.lua
@@ -1,0 +1,4 @@
+local L = LANG.GetLanguageTableReference("en")
+
+L["item_shootingspeed"] = "Shooting speed"
+L["item_shootingspeed_desc"] = "You shoot 30% faster!"

--- a/lua/terrortown/lang/pl/shootingspeed.lua
+++ b/lua/terrortown/lang/pl/shootingspeed.lua
@@ -1,0 +1,4 @@
+local L = LANG.GetLanguageTableReference("pl")
+
+L["item_shootingspeed"] = "Szybkość strzelania"
+L["item_shootingspeed_desc"] = "Strzelasz 30% szybciej!"


### PR DESCRIPTION
- Apply the buff to the active weapon when buying the item. Previously when the item was bought, the buff was not instantly applied to the held weapon. To apply it, the player had to switch the weapon.
- Fixed an error that popped up when the held weapon was switched with another laying on the ground.
- Added Polish translation